### PR TITLE
Fix typo in Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Whitespace separated list of test `.csproj` to run.
 
 **NOTES:**<br>
 - When running the tests with the flags `--docker` or `--cicd`, the tests will run inside a Docker container that will be in the `myapp_shared` network.
-- When running the script with the flags ``--integration` or `--e2e` the flag `--docker` is assumed as well, which means the tests will run inside a Docker container.
+- When running the script with the flags `--integration` or `--e2e` the flag `--docker` is assumed as well, which means the tests will run inside a Docker container.
 - You can use the `setup/local/.env.test` file to define envrionment variables to be used when starting the local development environment to be used for integration and E2E tests.
 
 ### Generating test coverage reports


### PR DESCRIPTION
Removed duplicate note about running tests with integration or e2e flags.